### PR TITLE
Fix logout method's continuation callback.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-xmpp",
   "description": "XMPP Social provider for freedomjs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-social-xmpp/issues",

--- a/src/socialprovider.js
+++ b/src/socialprovider.js
@@ -373,7 +373,7 @@ XMPPSocialProvider.prototype.onOnline = function(continuation) {
   continuation(this.vCardStore.getClient(this.id));
 };
 
-XMPPSocialProvider.prototype.logout = function(logoutOpts, continuation) {
+XMPPSocialProvider.prototype.logout = function(continuation) {
   var userId = this.credentials? this.credentials.userId : null;
 
   this.status = 'offline';


### PR DESCRIPTION
Fix logout method's continuation callback.  It should not have any logoutOpts (based on https://github.com/freedomjs/freedom/blob/master/interface/social.js) and this extra arg means that the continuation callback isn't working
