### PR TITLE
Change npm version # to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-xmpp",
   "description": "XMPP Social provider for freedomjs",
-  "version": "1.0.2",
+  "version": "0.2.0",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-social-xmpp/issues",


### PR DESCRIPTION
Change npm version # to 0.2.0, I've backed out all the 1.0.x versions and now 0.2.0 is published (https://www.npmjs.org/package/freedom-social-xmpp).  I'll create a new tagged release once this pull request is merged
