### PR TITLE
removing views from google/facebook

### DIFF
--- a/src/core/social.facebook.json
+++ b/src/core/social.facebook.json
@@ -15,11 +15,7 @@
   "permissions": [
     "core.tcpsocket",
     "core.udpsocket",
-    "core.view",
     "core.oauth",
     "core.storage"
-  ],
-  "views": {
-    "FacebookLogin": ["facebook-view.html", "facebook-view.js"]
-  }
+  ]
 }

--- a/src/core/social.google.json
+++ b/src/core/social.google.json
@@ -15,11 +15,7 @@
   "permissions": [
     "core.tcpsocket",
     "core.udpsocket",
-    "core.view",
     "core.oauth",
     "core.storage"
-  ],
-  "views": {
-    "GoogleLogin": ["google-view.html", "google-view.js"]
-  }
+  ]
 }


### PR DESCRIPTION
Forgot to remove these manifest attributes in v0.6 pull request. 
Fixing now. Malformed manifests cause errors in Radiatus
