### PR TITLE
switching to newer grunt-jasmine-node2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-jasmine-node');
+  grunt.loadNpmTasks('grunt-jasmine-node2');
   grunt.loadNpmTasks('grunt-prompt');
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-npm');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-contrib-copy": "~0.7.0",
     "grunt-contrib-jasmine": "^0.8.1",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-jasmine-node": "~0.2.1",
+    "grunt-jasmine-node2": "^0.4.0",
     "grunt-npm": "0.0.2",
     "grunt-prompt": "^1.3.0",
     "node-xmpp-client": "1.0.0-alpha19"


### PR DESCRIPTION
Switching from ~10 month old to ~2 month old package. Still not clear if grunt-jasmine-node(2) will be regularly updated or maintained in the long term, but this version is newer (uses console.log instead of util.print, which makes travis happier) and the tests in this repo still pass.