### PR TITLE
Try/catch around JSON.parse, only use type 'chat' for ONLINE_WITH_OTHER_APP

### DIFF
--- a/spec/socialprovider.spec.js
+++ b/spec/socialprovider.spec.js
@@ -231,7 +231,7 @@ describe("Tests for message batching in Social provider", function() {
     xmppSocialProvider.logout();
   });
 
-  it('parses JSON messages', function() {
+  it('parses JSON encoded arrays', function() {
     spyOn(xmppSocialProvider, 'dispatchEvent');
     var fromClient = xmppSocialProvider.vCardStore.getClient('fromId');
     var toClient = xmppSocialProvider.vCardStore.getClient('toId');
@@ -241,6 +241,16 @@ describe("Tests for message batching in Social provider", function() {
         'onMessage', {from: fromClient, to: toClient, message: 'abc'});
     expect(xmppSocialProvider.dispatchEvent).toHaveBeenCalledWith(
         'onMessage', {from: fromClient, to: toClient, message: 'def'});
+  });
+
+  it('does not parse JSON that is not an array', function() {
+    spyOn(xmppSocialProvider, 'dispatchEvent');
+    var jsonString = '{key: "value"}';
+    var fromClient = xmppSocialProvider.vCardStore.getClient('fromId');
+    var toClient = xmppSocialProvider.vCardStore.getClient('toId');
+    xmppSocialProvider.receiveMessage(fromClient, jsonString);
+    expect(xmppSocialProvider.dispatchEvent).toHaveBeenCalledWith(
+        'onMessage', {from: fromClient, to: toClient, message:jsonString});
   });
 
   it('does not parse non-JSON messages', function() {

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -284,7 +284,10 @@ XMPPSocialProvider.prototype.sendMessage = function(to, msg, continuation) {
         } else {
           body = '';
           for (i = 0; i < this.messages[to].length; i += 1) {
-            body += this.messages[to][i].message + '\n';
+            if (i > 0) {
+              body += '\n';
+            }
+            body += this.messages[to][i].message;
           }
           message.t(body);
         }

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -367,7 +367,11 @@ XMPPSocialProvider.prototype.onMessage = function(msg) {
 XMPPSocialProvider.prototype.receiveMessage = function(from, msgs) {
   var parsedMessages;
   try {
+    // Split msgs into an array only if it is a JSON formatted array.
     parsedMessages = JSON.parse(msgs);
+    if (!XMPPSocialProvider.isArray(parsedMessages)) {
+      parsedMessages = [msgs];
+    }
   } catch(e) {
     // msgs is not valid JSON, just emit one onMessage with that string.
     parsedMessages = [msgs];
@@ -580,6 +584,10 @@ XMPPSocialProvider.prototype.onUserChange = function(card) {
 
 XMPPSocialProvider.prototype.onClientChange = function(card) {
   this.dispatchEvent('onClientState', card);
+};
+
+XMPPSocialProvider.isArray = function(a) {
+  return Array.isArray ? Array.isArray(a) : (a instanceof Array);
 };
 
 // Register provider when in a module context.


### PR DESCRIPTION
Fix for https://github.com/uProxy/uproxy/issues/894 and possible fix for https://github.com/uProxy/uproxy/issues/885
* Add a try/catch around JSON.parse, and just emit 1 unparsed message if JSON.parse fails
* Only use message type 'chat' for ONLINE_WITH_OTHER_APP
* Only JSON encoding messages sent to ONLINE clients.  Messages sent to ONLINE_WITH_OTHER_APP and OFFLINE clients may be batched with '\n' separation (only if multiple messages are sent within the same short batching interval)

Tested with new grunt test cases