### PR TITLE
Handle end event by rejecting login promise or calling logout

### DIFF
--- a/spec/socialprovider.spec.js
+++ b/spec/socialprovider.spec.js
@@ -261,4 +261,24 @@ describe("Tests for message batching in Social provider", function() {
     expect(xmppSocialProvider.dispatchEvent).toHaveBeenCalledWith(
         'onMessage', {from: fromClient, to: toClient, message: 'hello'});
   });
+
+  it('end event rejects connect if not online', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    var continuationSpy = jasmine.createSpy('spy');
+    xmppSocialProvider.connect(continuationSpy);
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.client.events['end']();
+    expect(xmppSocialProvider.logout).not.toHaveBeenCalled();
+    expect(continuationSpy).toHaveBeenCalledWith(undefined,
+        {errcode: 'LOGIN_FAILEDCONNECTION', message: 'Received end event'});
+  });
+
+  it('end event calls logout if online', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    xmppSocialProvider.connect(function() {});
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.client.events['online']();
+    xmppSocialProvider.client.events['end']();
+    expect(xmppSocialProvider.logout).toHaveBeenCalled();
+  });
 });

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -184,8 +184,16 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
     this.logger.error('received unhandled close event', e);
   }.bind(this));
   this.client.addListener('end', function(e) {
-    // TODO: figure out when this is fired and handle this.
-    this.logger.error('received unhandled end event', e);
+    this.logger.error('received end event, status: ' + this.status, e);
+    if (this.status !== 'ONLINE') {
+      // Reject login promise.
+      continuation(undefined, {
+        errcode: 'LOGIN_FAILEDCONNECTION',
+        message: 'Received end event'
+      });
+    } else {
+      this.logout();
+    }
   }.bind(this));
   this.client.addListener('stanza', this.onMessage.bind(this));
 };


### PR DESCRIPTION
Fix for https://github.com/uProxy/uproxy/issues/912

Tested in updated "grunt test" (not sure why we sometimes get an 'end' event when logging into GTalk)