### PR TITLE
Ignore 'end' events caused by normal logout

### DIFF
--- a/spec/socialprovider.spec.js
+++ b/spec/socialprovider.spec.js
@@ -262,7 +262,7 @@ describe("Tests for message batching in Social provider", function() {
         'onMessage', {from: fromClient, to: toClient, message: 'hello'});
   });
 
-  it('end event rejects connect if not online', function() {
+  it('end event rejects connect if logging in', function() {
     spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
     var continuationSpy = jasmine.createSpy('spy');
     xmppSocialProvider.connect(continuationSpy);
@@ -280,5 +280,17 @@ describe("Tests for message batching in Social provider", function() {
     xmppSocialProvider.client.events['online']();
     xmppSocialProvider.client.events['end']();
     expect(xmppSocialProvider.logout).toHaveBeenCalled();
+  });
+
+  it('end event is ignored when user has logged out', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    var continuationSpy = jasmine.createSpy('spy');
+    xmppSocialProvider.connect(continuationSpy);
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.client.events['online']();
+    expect(continuationSpy.calls.count()).toBe(1);
+    xmppSocialProvider.logout();
+    expect(xmppSocialProvider.logout.calls.count()).toBe(1);
+    expect(continuationSpy.calls.count()).toBe(1);
   });
 });

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -179,10 +179,9 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
     this.vCardStore.updateProperty(this.id, 'status', 'OFFLINE');
   }.bind(this));
   this.client.addListener('close', function(e) {
-    // This may indicate a broken connection to XMPP.
-    // TODO: handle this.
-    this.logger.error('received unhandled close event', e);
+    this.logger.error('received close event', e);
     if (this.status === 'ONLINE') {
+      // Check if we are still online, otherwise log out.
       this.ping_();
     }
   }.bind(this));

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -37,7 +37,7 @@ var XMPPSocialProvider = function(dispatchEvent) {
   this.lastMessageTimestampMs_ = null;
   this.pollForDisconnectInterval_ = null;
   this.MAX_MS_WITHOUT_COMMUNICATION_ = 60000;
-  this.MAX_MS_PING_REPSONSE_ = 10000;
+  this.MAX_MS_PING_REPSONSE_ = 5000;
 
   // Metadata about the roster
   this.vCardStore = new VCardStore();
@@ -182,16 +182,21 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
     // This may indicate a broken connection to XMPP.
     // TODO: handle this.
     this.logger.error('received unhandled close event', e);
+    if (this.status === 'ONLINE') {
+      this.ping_();
+    }
   }.bind(this));
   this.client.addListener('end', function(e) {
-    this.logger.error('received end event, status: ' + this.status, e);
-    if (this.status !== 'ONLINE') {
-      // Reject login promise.
+    if (this.status !== 'ONLINE' && this.client) {
+      // Login is still pending, reject the login promise.
+      this.logger.error('Received end event while logging in');
       continuation(undefined, {
         errcode: 'LOGIN_FAILEDCONNECTION',
         message: 'Received end event'
       });
-    } else {
+    } else if (this.client) {
+      // Got an 'end' event without logout having been called, call logout.
+      this.logger.error('Received unexpected end event');
       this.logout();
     }
   }.bind(this));
@@ -202,7 +207,7 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
  * Clear any credentials / state in the app.
  * @method clearCachedCredentials
  */
-XMPPSocialProvider.prototype.clearCachedCredentials  = function(continuation) {
+XMPPSocialProvider.prototype.clearCachedCredentials = function(continuation) {
   delete this.credentials;
   continuation();
 };


### PR DESCRIPTION
Ignore 'end' events caused by normal logout, fixes https://github.com/uProxy/uproxy/issues/1022

Tested in Chrome and with updated 'grunt test'