### PR TITLE
logout shouldnt clear credentials

### DIFF
--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -203,7 +203,7 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
  * @method clearCachedCredentials
  */
 XMPPSocialProvider.prototype.clearCachedCredentials  = function(continuation) {
-  delete this.credentials;
+  this.credentials = null;
   continuation();
 };
 
@@ -557,7 +557,6 @@ XMPPSocialProvider.prototype.startPollingForDisconnect_ = function() {
 
 XMPPSocialProvider.prototype.logout = function(continuation) {
   this.status = 'offline';
-  this.credentials = null;
   this.lastMessageTimestampMs_ = null;
   if (this.pollForDisconnectInterval_) {
     clearInterval(this.pollForDisconnectInterval_);


### PR DESCRIPTION
For consideration - while working on https://github.com/freedomjs/freedom-social-email I used this provider for reference, and think that perhaps we should (a) not clear credentials on logout (that's what clearCredentials is for) and less importantly (b) clear credentials by setting to null (since that's the "default state"). Thoughts/feedback welcome, whatever we decide here I'll mimic in other the email provider/elsewhere.