### PR TITLE
Manage behaviour of trying to create more than one XMPP client.

### DIFF
--- a/spec/socialprovider.spec.js
+++ b/spec/socialprovider.spec.js
@@ -213,6 +213,9 @@ describe("Tests for message batching in Social provider", function() {
   describe("Tests for connection", function() {
 
     beforeEach(function() {
+      // Since the client was set in the top-level beforeEach, set it to null
+      // here. Otherwise, connect() will call logout on the social provider
+      // before creating a new client (which would affect our logout spies).
       xmppSocialProvider.client = null;
     });
 

--- a/spec/socialprovider.spec.js
+++ b/spec/socialprovider.spec.js
@@ -56,10 +56,8 @@ describe("Tests for message batching in Social provider", function() {
     // Mock VCardStore, Date and the client.
     function dispatchEvent(eventType, data) {};
     xmppSocialProvider = new XMPPSocialProvider(dispatchEvent);
-    xmppSocialProvider.client = xmppClient;
     xmppSocialProvider.id = 'myId';
     xmppSocialProvider.loginOpts = {};
-    spyOn(xmppSocialProvider.client, 'send');
 
     jasmine.clock().install();
   });
@@ -69,6 +67,7 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it("add first message to batch and save time of message", function() {
+    xmppSocialProvider.client = xmppClient;
     dateSpy = spyOn(Date, "now").and.returnValue(500);
     xmppSocialProvider.sendMessage('Bob', 'Hi', function() {});
     expect(xmppSocialProvider.messages.Bob[0].message).toEqual('Hi');
@@ -76,12 +75,15 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it("set callback after first message is added to batch", function() {
+    xmppSocialProvider.client = xmppClient;
     expect(xmppSocialProvider.sendMessagesTimeout).toBeNull();
     xmppSocialProvider.sendMessage('Bob', 'Hi', function() {});
     expect(xmppSocialProvider.sendMessagesTimeout).not.toBeNull();
   });
 
   it("send message after 100ms", function() {
+    xmppSocialProvider.client = xmppClient;
+    spyOn(xmppSocialProvider.client, 'send');
     xmppSocialProvider.sendMessage('Bob', 'Hi', function() {});
     expect(xmppSocialProvider.client.send).not.toHaveBeenCalled();
     jasmine.clock().tick(100);
@@ -90,6 +92,8 @@ describe("Tests for message batching in Social provider", function() {
 
 
   it("calls callback after send", function() {
+    xmppSocialProvider.client = xmppClient;
+    spyOn(xmppSocialProvider.client, 'send');
     var spy = jasmine.createSpy('callback');
     xmppSocialProvider.sendMessage('Bob', 'Hi', spy);
     expect(xmppSocialProvider.client.send).not.toHaveBeenCalled();
@@ -100,6 +104,8 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it("timeout resets to 100ms after each message", function() {
+    xmppSocialProvider.client = xmppClient;
+    spyOn(xmppSocialProvider.client, 'send');
     xmppSocialProvider.sendMessage('Bob', 'Hi', function() {});
     expect(xmppSocialProvider.client.send).not.toHaveBeenCalled();
     jasmine.clock().tick(50);
@@ -119,6 +125,8 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it("do not reset timeout if oldest message is from >=2s ago", function() {
+    xmppSocialProvider.client = xmppClient;
+    spyOn(xmppSocialProvider.client, 'send');
     dateSpy = spyOn(Date, "now").and.returnValue(500);
     xmppSocialProvider.sendMessage('Bob', 'Hi', function() {});
     expect(xmppSocialProvider.client.send).not.toHaveBeenCalled();
@@ -145,6 +153,8 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it("sends message to correct destinations", function() {
+    xmppSocialProvider.client = xmppClient;
+    spyOn(xmppSocialProvider.client, 'send');
     xmppSocialProvider.sendMessage('Bob', 'Hi', function() {});
     xmppSocialProvider.sendMessage('Alice', 'Hi', function() {});
     expect(xmppSocialProvider.client.send).not.toHaveBeenCalled();
@@ -181,7 +191,7 @@ describe("Tests for message batching in Social provider", function() {
     xmppSocialProvider.connect();
     xmppSocialProvider.ping_();
     jasmine.clock().tick(xmppSocialProvider.MAX_MS_PING_REPSONSE_ + 10);
-    expect(xmppSocialProvider.logout).toHaveBeenCalled();
+    expect(xmppSocialProvider.logout.calls.count()).toEqual(1);
   });
 
   it('stays online when ping response received', function() {
@@ -252,6 +262,7 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it('parses JSON encoded arrays', function() {
+    xmppSocialProvider.client = xmppClient;
     spyOn(xmppSocialProvider, 'dispatchEvent');
     var fromClient = xmppSocialProvider.vCardStore.getClient('fromId');
     var toClient = xmppSocialProvider.vCardStore.getClient('myId');
@@ -263,6 +274,7 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it('does not parse JSON that is not an array', function() {
+    xmppSocialProvider.client = xmppClient;
     spyOn(xmppSocialProvider, 'dispatchEvent');
     var jsonString = '{key: "value"}';
     var fromClient = xmppSocialProvider.vCardStore.getClient('fromId');
@@ -273,6 +285,7 @@ describe("Tests for message batching in Social provider", function() {
   });
 
   it('does not parse non-JSON messages', function() {
+    xmppSocialProvider.client = xmppClient;
     spyOn(xmppSocialProvider, 'dispatchEvent');
     var fromClient = xmppSocialProvider.vCardStore.getClient('fromId');
     var toClient = xmppSocialProvider.vCardStore.getClient('myId');
@@ -298,7 +311,7 @@ describe("Tests for message batching in Social provider", function() {
     spyOn(xmppSocialProvider, 'logout');
     xmppSocialProvider.client.events['online']();
     xmppSocialProvider.client.events['end']();
-    expect(xmppSocialProvider.logout).toHaveBeenCalled();
+    expect(xmppSocialProvider.logout.calls.count()).toEqual(1);
   });
 
   it('end event is ignored when user has logged out', function() {
@@ -315,6 +328,7 @@ describe("Tests for message batching in Social provider", function() {
 
   it('creates ONLINE_WITH_OTHER_APP client for messages from unknown client',
       function() {
+    xmppSocialProvider.client = xmppClient;
     spyOn(xmppSocialProvider, 'dispatchEvent');
 
     var message = new window.XMPP.Element(

--- a/spec/socialprovider.spec.js
+++ b/spec/socialprovider.spec.js
@@ -88,6 +88,7 @@ describe("Tests for message batching in Social provider", function() {
     expect(xmppSocialProvider.client.send).toHaveBeenCalled();
   });
 
+
   it("calls callback after send", function() {
     var spy = jasmine.createSpy('callback');
     xmppSocialProvider.sendMessage('Bob', 'Hi', spy);
@@ -163,6 +164,93 @@ describe("Tests for message batching in Social provider", function() {
     }
   });
 
+  it('sets status to OFFLINE when client disconnected', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    xmppSocialProvider.connect();
+    xmppSocialProvider.id = 'id'
+    expect(xmppSocialProvider.client.events['offline']).toBeDefined();
+    spyOn(xmppSocialProvider.vCardStore, 'updateProperty');
+    xmppSocialProvider.client.events['offline']();
+    expect(xmppSocialProvider.vCardStore.updateProperty)
+        .toHaveBeenCalledWith('id', 'status', 'OFFLINE');
+  });
+
+  it('disconnects when no reply to ping', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.connect();
+    xmppSocialProvider.ping_();
+    jasmine.clock().tick(xmppSocialProvider.MAX_MS_PING_REPSONSE_ + 10);
+    expect(xmppSocialProvider.logout).toHaveBeenCalled();
+  });
+
+  it('stays online when ping response received', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.connect();
+    xmppSocialProvider.ping_();
+    xmppSocialProvider.onMessage(
+        new window.XMPP.Element('iq', {type: 'result'}));
+    jasmine.clock().tick(xmppSocialProvider.MAX_MS_PING_REPSONSE_ + 10);
+    expect(xmppSocialProvider.logout).not.toHaveBeenCalled();
+  });
+
+  it('pings once per minute if no message received', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    // Set Math.random so that we immediately hit the once-per-minute ping case.
+    spyOn(Math, 'random').and.returnValue((new Date()).getSeconds() / 60);
+    spyOn(xmppSocialProvider, 'ping_')
+    xmppSocialProvider.connect(function() {});
+    // Emit online event to start polling loop.
+    xmppSocialProvider.client.events['online']();
+    jasmine.clock().tick(1001);
+    expect(xmppSocialProvider.ping_).toHaveBeenCalled();
+    // logout must be called to clearInterval on the polling loop
+    xmppSocialProvider.logout();
+  });
+
+  it('does not ping once per minute if a message is received', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    // Set Math.random so that we immediately hit the once-per-minute ping case.
+    spyOn(Math, 'random').and.returnValue((new Date()).getSeconds() / 60);
+    spyOn(xmppSocialProvider, 'ping_')
+    xmppSocialProvider.connect(function() {});
+    // Emit online event to start polling loop.
+    xmppSocialProvider.client.events['online']();
+    // Send a message before the next polling loop.
+    xmppSocialProvider.onMessage(
+        new window.XMPP.Element('iq', {type: 'result'}));
+    jasmine.clock().tick(1001);
+    expect(xmppSocialProvider.ping_).not.toHaveBeenCalled();
+    // logout must be called to clearInterval on the polling loop
+    xmppSocialProvider.logout();
+  });
+
+  it('detects sleep and pings immediately', function() {
+    var nowMs = 0;
+    dateSpy = spyOn(Date, "now").and.callFake(function() { return nowMs; });
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    var setIntervalCallbacks = [];
+    spyOn(window, 'setInterval').and.callFake(function(callback, intervalMs) {
+      setIntervalCallbacks.push(callback);
+    });
+    spyOn(xmppSocialProvider, 'ping_');
+
+    // Connect and emit online event to start polling loop.
+    xmppSocialProvider.connect(function() {});
+    xmppSocialProvider.client.events['online']();
+
+    // Advance the clock by 2010 ms and invoke callbacks.
+    nowMs = 2010;
+    jasmine.clock().tick(2010);
+    setIntervalCallbacks.map(function(callback) { callback(); });
+
+    // Expect sleep to have been detected and ping to be invoked.
+    expect(xmppSocialProvider.ping_).toHaveBeenCalled();
+    // logout must be called to clearInterval on the polling loop
+    xmppSocialProvider.logout();
+  });
+
   it('parses JSON encoded arrays', function() {
     spyOn(xmppSocialProvider, 'dispatchEvent');
     var fromClient = xmppSocialProvider.vCardStore.getClient('fromId');
@@ -193,6 +281,38 @@ describe("Tests for message batching in Social provider", function() {
         'onMessage', {from: fromClient, to: toClient, message: 'hello'});
   });
 
+  it('end event rejects connect if logging in', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    var continuationSpy = jasmine.createSpy('spy');
+    xmppSocialProvider.connect(continuationSpy);
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.client.events['end']();
+    expect(xmppSocialProvider.logout).not.toHaveBeenCalled();
+    expect(continuationSpy).toHaveBeenCalledWith(undefined,
+        {errcode: 'LOGIN_FAILEDCONNECTION', message: 'Received end event'});
+  });
+
+  it('end event calls logout if online', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    xmppSocialProvider.connect(function() {});
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.client.events['online']();
+    xmppSocialProvider.client.events['end']();
+    expect(xmppSocialProvider.logout).toHaveBeenCalled();
+  });
+
+  it('end event is ignored when user has logged out', function() {
+    spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
+    var continuationSpy = jasmine.createSpy('spy');
+    xmppSocialProvider.connect(continuationSpy);
+    spyOn(xmppSocialProvider, 'logout');
+    xmppSocialProvider.client.events['online']();
+    expect(continuationSpy.calls.count()).toBe(1);
+    xmppSocialProvider.logout();
+    expect(xmppSocialProvider.logout.calls.count()).toBe(1);
+    expect(continuationSpy.calls.count()).toBe(1);
+  });
+
   it('creates ONLINE_WITH_OTHER_APP client for messages from unknown client',
       function() {
     spyOn(xmppSocialProvider, 'dispatchEvent');
@@ -208,134 +328,5 @@ describe("Tests for message batching in Social provider", function() {
           to: {clientId: 'myId', status: 'ONLINE' },
           message: 'hello'
         });
-  });
-
-  describe("Tests for connection", function() {
-
-    beforeEach(function() {
-      // Since the client was set in the top-level beforeEach, set it to null
-      // here. Otherwise, connect() will call logout on the social provider
-      // before creating a new client (which would affect our logout spies).
-      xmppSocialProvider.client = null;
-    });
-
-    it('end event rejects connect if logging in', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      var continuationSpy = jasmine.createSpy('spy');
-      xmppSocialProvider.connect(continuationSpy);
-      spyOn(xmppSocialProvider, 'logout');
-      xmppSocialProvider.client.events['end']();
-      expect(xmppSocialProvider.logout).not.toHaveBeenCalled();
-      expect(continuationSpy).toHaveBeenCalledWith(undefined,
-          {errcode: 'LOGIN_FAILEDCONNECTION', message: 'Received end event'});
-    });
-
-    it('sets status to OFFLINE when client disconnected', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      xmppSocialProvider.connect();
-      xmppSocialProvider.id = 'id'
-      expect(xmppSocialProvider.client.events['offline']).toBeDefined();
-      spyOn(xmppSocialProvider.vCardStore, 'updateProperty');
-      xmppSocialProvider.client.events['offline']();
-      expect(xmppSocialProvider.vCardStore.updateProperty)
-          .toHaveBeenCalledWith('id', 'status', 'OFFLINE');
-    });
-
-    it('disconnects when no reply to ping', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      spyOn(xmppSocialProvider, 'logout');
-      xmppSocialProvider.connect();
-      xmppSocialProvider.ping_();
-      jasmine.clock().tick(xmppSocialProvider.MAX_MS_PING_REPSONSE_ + 10);
-      expect(xmppSocialProvider.logout.calls.count()).toEqual(1);
-    });
-
-    it('stays online when ping response received', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      spyOn(xmppSocialProvider, 'logout');
-      xmppSocialProvider.connect();
-      xmppSocialProvider.ping_();
-      xmppSocialProvider.onMessage(
-          new window.XMPP.Element('iq', {type: 'result'}));
-      jasmine.clock().tick(xmppSocialProvider.MAX_MS_PING_REPSONSE_ + 10);
-      expect(xmppSocialProvider.logout).not.toHaveBeenCalled();
-    });
-
-    it('pings once per minute if no message received', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      // Set Math.random so that we immediately hit the once-per-minute ping case.
-      spyOn(Math, 'random').and.returnValue((new Date()).getSeconds() / 60);
-      spyOn(xmppSocialProvider, 'ping_')
-      xmppSocialProvider.connect(function() {});
-      // Emit online event to start polling loop.
-      xmppSocialProvider.client.events['online']();
-      jasmine.clock().tick(1001);
-      expect(xmppSocialProvider.ping_).toHaveBeenCalled();
-      // logout must be called to clearInterval on the polling loop
-      xmppSocialProvider.logout();
-    });
-
-    it('does not ping once per minute if a message is received', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      // Set Math.random so that we immediately hit the once-per-minute ping case.
-      spyOn(Math, 'random').and.returnValue((new Date()).getSeconds() / 60);
-      spyOn(xmppSocialProvider, 'ping_')
-      xmppSocialProvider.connect(function() {});
-      // Emit online event to start polling loop.
-      xmppSocialProvider.client.events['online']();
-      // Send a message before the next polling loop.
-      xmppSocialProvider.onMessage(
-          new window.XMPP.Element('iq', {type: 'result'}));
-      jasmine.clock().tick(1001);
-      expect(xmppSocialProvider.ping_).not.toHaveBeenCalled();
-      // logout must be called to clearInterval on the polling loop
-      xmppSocialProvider.logout();
-    });
-
-    it('detects sleep and pings immediately', function() {
-      var nowMs = 0;
-      dateSpy = spyOn(Date, "now").and.callFake(function() { return nowMs; });
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      var setIntervalCallbacks = [];
-      spyOn(window, 'setInterval').and.callFake(function(callback, intervalMs) {
-        setIntervalCallbacks.push(callback);
-      });
-      spyOn(xmppSocialProvider, 'ping_');
-
-      // Connect and emit online event to start polling loop.
-      xmppSocialProvider.connect(function() {});
-      xmppSocialProvider.client.events['online']();
-
-      // Advance the clock by 2010 ms and invoke callbacks.
-      nowMs = 2010;
-      jasmine.clock().tick(2010);
-      setIntervalCallbacks.map(function(callback) { callback(); });
-
-      // Expect sleep to have been detected and ping to be invoked.
-      expect(xmppSocialProvider.ping_).toHaveBeenCalled();
-      // logout must be called to clearInterval on the polling loop
-      xmppSocialProvider.logout();
-    });
-
-    it('end event calls logout if online', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      xmppSocialProvider.connect(function() {});
-      spyOn(xmppSocialProvider, 'logout');
-      xmppSocialProvider.client.events['online']();
-      xmppSocialProvider.client.events['end']();
-      expect(xmppSocialProvider.logout).toHaveBeenCalled();
-    });
-
-    it('end event is ignored when user has logged out', function() {
-      spyOn(window.XMPP, 'Client').and.returnValue(xmppClient);
-      var continuationSpy = jasmine.createSpy('spy');
-      xmppSocialProvider.connect(continuationSpy);
-      spyOn(xmppSocialProvider, 'logout');
-      xmppSocialProvider.client.events['online']();
-      expect(continuationSpy.calls.count()).toBe(1);
-      xmppSocialProvider.logout();
-      expect(xmppSocialProvider.logout.calls.count()).toBe(1);
-      expect(continuationSpy.calls.count()).toBe(1);
-    });
   });
 });

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -123,14 +123,11 @@ XMPPSocialProvider.prototype.initializeState = function() {
  */
 XMPPSocialProvider.prototype.connect = function(continuation) {
   if (this.client) {
-    var tempCredentials = this.credentials;
+    // Store our new credentials since logging out the old client
+    // will clear this.credentials.
+    var newCredentials = this.credentials;
     this.logout();
-    this.credentials = tempCredentials;
-    // continuation(undefined, {
-    //   errcode: 'LOGIN_ALREADYEXISTS',
-    //   message: 'another attempt to login is pending'
-    // });
-    // return;
+    this.credentials = newCredentials;
   }
 
   var key, jid, connectOpts = {

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -122,6 +122,17 @@ XMPPSocialProvider.prototype.initializeState = function() {
  * @param {Function} continuation Callback upon connection
  */
 XMPPSocialProvider.prototype.connect = function(continuation) {
+  if (this.client) {
+    var tempCredentials = this.credentials;
+    this.logout();
+    this.credentials = tempCredentials;
+    // continuation(undefined, {
+    //   errcode: 'LOGIN_ALREADYEXISTS',
+    //   message: 'another attempt to login is pending'
+    // });
+    // return;
+  }
+
   var key, jid, connectOpts = {
     xmlns: 'jabber:client',
     jid: this.id,

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -174,7 +174,7 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
 
 
     if (this.client) {
-      this.client.end();
+      this.logout();
     }
   }.bind(this));
   this.client.addListener('offline', function(e) {

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -167,7 +167,6 @@ XMPPSocialProvider.prototype.connect = function(continuation) {
 
     if (this.client) {
       this.client.end();
-      delete this.client;
     }
   }.bind(this));
   this.client.addListener('offline', function(e) {
@@ -588,6 +587,12 @@ XMPPSocialProvider.prototype.logout = function(continuation) {
     this.client.send(new window.XMPP.Element('presence', {
       type: 'unavailable'
     }));
+    this.client.removeAllListeners('online');
+    this.client.removeAllListeners('error');
+    this.client.removeAllListeners('offline');
+    this.client.removeAllListeners('close');
+    this.client.removeAllListeners('end');
+    this.client.removeAllListeners('stanza');
     this.client.end();
     this.client = null;
   }

--- a/src/core/socialprovider.js
+++ b/src/core/socialprovider.js
@@ -595,13 +595,15 @@ XMPPSocialProvider.prototype.logout = function(continuation) {
     this.client.send(new window.XMPP.Element('presence', {
       type: 'unavailable'
     }));
+    this.client.end();
+    // end() still relies on the client's event listeners
+    // so they can only be removed after calling end().
     this.client.removeAllListeners('online');
     this.client.removeAllListeners('error');
     this.client.removeAllListeners('offline');
     this.client.removeAllListeners('close');
     this.client.removeAllListeners('end');
     this.client.removeAllListeners('stanza');
-    this.client.end();
     this.client = null;
   }
   if (continuation) {


### PR DESCRIPTION
- Remove all client listeners on logout
- If we call connect when a client already exists, log out the old client first
Tested manually with Chrome and Firefox and I believe that it will fix https://github.com/uProxy/uproxy/issues/1370
At least, this prevents a few module crashes I've been able to reproduce.